### PR TITLE
Add one line docstrings for editor intellisense support

### DIFF
--- a/sending/logging.py
+++ b/sending/logging.py
@@ -1,3 +1,4 @@
+"""Logging configuration"""
 import logging
 import os
 

--- a/sending/metrics.py
+++ b/sending/metrics.py
@@ -1,3 +1,4 @@
+"""Metrics for monitoring pub-sub operations"""
 from prometheus_client import Counter, Gauge, Histogram
 
 NAMESPACE = "sending"

--- a/sending/util.py
+++ b/sending/util.py
@@ -1,3 +1,4 @@
+"""Utilities for common tasks"""
 import inspect
 from itertools import islice
 from typing import Callable, Coroutine, Iterator, List
@@ -9,6 +10,7 @@ def split_collection(c, slices) -> List[Iterator]:
 
 
 def ensure_async(fn: Callable) -> Coroutine:
+    """A decorator that can be used to require async behavior."""
     if inspect.iscoroutinefunction(fn):
         return fn
 


### PR DESCRIPTION
Nick, the project is off to a great start and will help simplify some stuff around message subscriptions.

I've added one-line docstrings for two reasons: 1) it allows intellisense in VSCode and PyCharm to display the one line on hover providing faster developer context of the function's purpose; 2) pub-sub is confusing and it will make things a bit easier when new engineers use the codebase down the road.