### PR TITLE
make websockets backend use sync .send like base

### DIFF
--- a/sending/backends/websocket.py
+++ b/sending/backends/websocket.py
@@ -96,7 +96,7 @@ class WebsocketManager(AbstractPubSubManager):
         """
         self.authed_ws.set_result(self.unauth_ws.result())
 
-    async def send(self, message: Any):
+    def send(self, message: Any):
         """
         Override the default Sending behavior to only accept a message instead of topic + message.
         Topic is not a concept supported in this Backend.

--- a/tests/test_websocket_backend.py
+++ b/tests/test_websocket_backend.py
@@ -8,7 +8,6 @@ import pytest
 from managed_service_fixtures import AppDetails, AppManager
 
 from sending.backends.websocket import WebsocketManager
-from sending.base import QueuedMessage
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_websocket_backend.py
+++ b/tests/test_websocket_backend.py
@@ -8,6 +8,7 @@ import pytest
 from managed_service_fixtures import AppDetails, AppManager
 
 from sending.backends.websocket import WebsocketManager
+from sending.base import QueuedMessage
 
 
 @pytest.fixture(scope="session")
@@ -66,7 +67,7 @@ async def test_basic_send(manager: WebsocketManager):
     """
     await manager.initialize()
     assert manager.auth_hook is None
-    await manager.send(json.dumps({"type": "unauthed_echo_request", "text": "Hello plain_manager"}))
+    manager.send(json.dumps({"type": "unauthed_echo_request", "text": "Hello plain_manager"}))
     await asyncio.wait_for(manager.next_event.wait(), 1)
     reply = json.loads(manager.last_seen_message)
     assert reply == {"type": "unauthed_echo_reply", "text": "Hello plain_manager"}
@@ -77,7 +78,7 @@ async def test_message_hooks(json_manager: WebsocketManager):
     Test that the inbound and outbound message hooks serialize/deserialize json
     """
     await json_manager.initialize()
-    await json_manager.send({"type": "unauthed_echo_request", "text": "Hello json_manager"})
+    json_manager.send({"type": "unauthed_echo_request", "text": "Hello json_manager"})
     reply = await run_until_message_type(json_manager, "unauthed_echo_reply")
     assert reply == {"type": "unauthed_echo_reply", "text": "Hello json_manager"}
 
@@ -88,7 +89,7 @@ async def test_init_hook(json_manager: WebsocketManager):
     """
 
     async def init_hook(mgr: WebsocketManager):
-        await mgr.send({"type": "unauthed_echo_request", "text": "Hello init_hook"})
+        mgr.send({"type": "unauthed_echo_request", "text": "Hello init_hook"})
 
     json_manager.init_hook = init_hook
     await json_manager.initialize()
@@ -159,7 +160,7 @@ async def test_auth_on_reconnect(json_manager: WebsocketManager, websocket_serve
     )
     await json_manager.initialize()
     # test that we're authenticated on the server side
-    await json_manager.send({"type": "authed_echo_request", "text": "Hello auth"})
+    json_manager.send({"type": "authed_echo_request", "text": "Hello auth"})
     reply = await run_until_message_type(json_manager, "authed_echo_reply")
     assert reply == {"type": "authed_echo_reply", "text": "Hello auth"}
 
@@ -168,7 +169,7 @@ async def test_auth_on_reconnect(json_manager: WebsocketManager, websocket_serve
         resp = await client.get(f"/disconnect/{token}")
     assert resp.status_code == 204
 
-    await json_manager.send({"type": "authed_echo_request", "text": "Hello auth2"})
+    json_manager.send({"type": "authed_echo_request", "text": "Hello auth2"})
     reply = await run_until_message_type(json_manager, "authed_echo_reply")
     assert reply == {"type": "authed_echo_reply", "text": "Hello auth2"}
 
@@ -202,7 +203,7 @@ async def test_hooks_in_subclass(websocket_server: AppDetails):
 
     mgr = Sub(ws_url=websocket_server.ws_base + "/ws")
     await mgr.initialize()
-    await mgr.send({"type": "authed_echo_request", "text": "Hello subclass"})
+    mgr.send({"type": "authed_echo_request", "text": "Hello subclass"})
     reply = await run_until_message_type(mgr, "authed_echo_reply")
     assert reply == {"type": "authed_echo_reply", "text": "Hello subclass"}
     await mgr.shutdown()


### PR DESCRIPTION
Oversight when designing the `WesocketManager` that its `.send` method was async while all other Sending backends are sync. These things can be sync because they're not actually putting anything on the wire, just dropping it into the outbound message queue.

Note it can be confusing that the underlying websockets library has an async `.send` method, so there will be some code that looks like `mgr.send` right next to `await mgr.ws.send` 🤷‍♂️ . I figure better to be consistent with other backends though, and want to get this in before the `WebsocketManager` is widely used.