### PR TITLE
optional arg in initialize to avoid creating network io

### DIFF
--- a/tests/test_websocket_backend.py
+++ b/tests/test_websocket_backend.py
@@ -8,6 +8,7 @@ import pytest
 from managed_service_fixtures import AppDetails, AppManager
 
 from sending.backends.websocket import WebsocketManager
+from sending.base import QueuedMessage
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
Little flag to make testing easier. `await mgr.initialize(enable_polling=False)` will start the inbound and outbound queue workers, but not the poll worker. That way your backend won't start making IO connections, and you can test registered callbacks that use `.send` by asserting `._publish` was called while triggering the callbacks using `.schedule_for_delivery`.