### PR TITLE
switch from structlog to vanilla logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Use `managed_service_fixtures` for Redis tests
+- `WebsocketManager` backend uses vanilla `logging` instead of `structlog`, remove need for `structlog` dependency once `managed-service-fixtures` also drops it
 
 ## [0.2.2] - 2022-07-28
 ### Changed

--- a/README.md
+++ b/README.md
@@ -65,29 +65,3 @@ nox -s lint
 ```
 nox -s lint_check
 ```
-
-## Websocket Logging
-
-`WebsocketBackend` uses `structlog` for its logs. To view or suppress logs such as `Sending` and `Received` for all messages coming over the websocket, use this minimal structlog code.
-
-```
-import structlog
-import logging
-
-processors = [
-    structlog.stdlib.add_logger_name,
-    structlog.stdlib.add_log_level,
-    structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
-]
-
-structlog.configure(
-    processors=processors, logger_factory=structlog.stdlib.LoggerFactory()
-)
-
-logging.basicConfig()
-# enable debug logs
-logging.getLogger("sending.backends.websocket").setLevel(logging.DEBUG)
-
-# suppress debug logs
-logging.getLogger("sending.backends.websocket").setLevel(logging.INFO)
-```

--- a/sending/backends/websocket.py
+++ b/sending/backends/websocket.py
@@ -1,13 +1,13 @@
 import asyncio
+import logging
 from typing import Any, Callable, Optional
 
-import structlog
 import websockets
 
 from sending.base import AbstractPubSubManager, QueuedMessage
 from sending.util import ensure_async
 
-logger = structlog.get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 class WebsocketManager(AbstractPubSubManager):


### PR DESCRIPTION
Now that I have examples of how to add spans/traces / contextvars to vanilla logging I'm good with switching out structlog to vanilla logging in sending.