### PR TITLE
Save websocket response headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - CI/CD files and noxfile syntax
 - `WebsocketManager` Backend
 - New extra install `-E websockets`, additionally a convenience `-E all` option
+- `WebsocketManager` saves response headers on connect
 
 ### Changed
 - Use `managed_service_fixtures` for Redis tests

--- a/sending/backends/websocket.py
+++ b/sending/backends/websocket.py
@@ -35,6 +35,9 @@ class WebsocketManager(AbstractPubSubManager):
         super().__init__()
         self.ws_url = ws_url
 
+        # Save / overwrite response headers on each connection
+        self.response_headers = {}
+
         # An unauth_ws and authed_ws pair of Futures are created so that
         # sub-classes can easily implement a pattern where messages are only
         # sent to the server after the session has been authenticated.
@@ -144,6 +147,7 @@ class WebsocketManager(AbstractPubSubManager):
         """
         # Automatic reconnect https://websockets.readthedocs.io/en/stable/reference/client.html
         async for websocket in websockets.connect(self.ws_url):
+            self.response_headers = dict(websocket.response_headers)
             try:
                 self.unauth_ws.set_result(websocket)
                 # Call the auth and init hooks (casting to async if necessary), passing in 'self'

--- a/tests/test_websocket_backend.py
+++ b/tests/test_websocket_backend.py
@@ -73,6 +73,22 @@ async def test_basic_send(manager: WebsocketManager):
     assert reply == {"type": "unauthed_echo_reply", "text": "Hello plain_manager"}
 
 
+async def test_response_header(manager: WebsocketManager):
+    """
+    The test websocket server will return a handful of response headers as part of the
+    websocket connection, such as {'upgrade': 'websocket', 'connection': 'Upgrade'}, etc.
+    It also includes a custom header {'foo': 'bar'}. In real world situations that response
+    header might be something like {'rtu-session-id': '<uuid>'}. Test that we save off
+    the response headers to the Manager instance on connect.
+    """
+    await manager.initialize()
+    # Give it a moment to connect
+    await asyncio.sleep(0.01)
+    assert (
+        manager.response_headers.get("foo") == "bar"
+    ), f"Missing foo: bar from {dict(manager.response_headers)}"
+
+
 async def test_message_hooks(json_manager: WebsocketManager):
     """
     Test that the inbound and outbound message hooks serialize/deserialize json

--- a/tests/websocket_server.py
+++ b/tests/websocket_server.py
@@ -47,7 +47,7 @@ class WebsocketManager:
     dependency = singleton
 
     async def connect(self, session: WebsocketSession):
-        await session.ws.accept()
+        await session.ws.accept(headers=[(b"foo", b"bar")])
         self.sessions.append(session)
 
     async def disconnect(self, session: WebsocketSession):


### PR DESCRIPTION
Need websocket response headers saved off so that `RTUManager` and the RTU clients in PA/Origami can reference `rtu-session-id` set by Gate or any generic RTU validation server.