### PR TITLE
Add more hooks to support structlog contextvars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - CI/CD files and noxfile syntax
 - `WebsocketManager` Backend
 - New extra install `-E websockets`, additionally a convenience `-E all` option
-- `WebsocketManager` saves response headers on connect
+- `context_hook` in Base Manager that can be used to bind structlog contextvars for all workers (inbound, outbound, poll)
+- `connect_hook` and `disconnect_hook` for Websocket manager
 
 ### Changed
 - Use `managed_service_fixtures` for Redis tests

--- a/poetry.lock
+++ b/poetry.lock
@@ -178,7 +178,7 @@ development = ["black", "flake8", "mypy", "pytest", "types-colorama"]
 
 [[package]]
 name = "coverage"
-version = "6.4.2"
+version = "6.4.4"
 description = "Code coverage measurement for Python"
 category = "dev"
 optional = false
@@ -1085,7 +1085,7 @@ websockets = ["websockets"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "d08ee19f9a80b2ed66d6f3637566f8c5a8da8f513e2b4731491fff8a82cc66e7"
+content-hash = "8c5221b4f2140b47cbf6de9460ba3175a107b492396e9df3b809bce62694283b"
 
 [metadata.files]
 aioredis = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ pytest-cov = "^3.0.0"
 uvicorn = "^0.18.2"
 fastapi = "^0.79.0"
 httpx = "^0.23.0"
+structlog = "^22.1.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/sending/backends/websocket.py
+++ b/sending/backends/websocket.py
@@ -35,9 +35,6 @@ class WebsocketManager(AbstractPubSubManager):
         super().__init__()
         self.ws_url = ws_url
 
-        # Save / overwrite response headers on each connection
-        self.response_headers = {}
-
         # An unauth_ws and authed_ws pair of Futures are created so that
         # sub-classes can easily implement a pattern where messages are only
         # sent to the server after the session has been authenticated.

--- a/sending/backends/websocket.py
+++ b/sending/backends/websocket.py
@@ -43,7 +43,9 @@ class WebsocketManager(AbstractPubSubManager):
         # sent to the server after the session has been authenticated.
         self.unauth_ws = asyncio.Future()
         self.authed_ws = asyncio.Future()
-        # Set / unset by connection and disconnection hooks
+        # Can use await mgr.connected.wait() to block until the websocket is connected
+        # in tests or in situations where you want connect_hook / context_hook to have
+        # information available to it from the websocket response (e.g. RTU session id)
         self.connected = asyncio.Event()
 
         # When an outbound worker is ready to send a message over the wire, it

--- a/sending/base.py
+++ b/sending/base.py
@@ -5,7 +5,7 @@ import asyncio
 import enum
 from collections import defaultdict, namedtuple
 from functools import partial, wraps
-from typing import Callable, Coroutine, Dict, List, Optional, Set
+from typing import Callable, Dict, List, Optional, Set
 from uuid import UUID, uuid4
 
 from .logging import logger

--- a/tests/test_websocket_backend.py
+++ b/tests/test_websocket_backend.py
@@ -5,6 +5,7 @@ from typing import Callable
 
 import httpx
 import pytest
+import structlog
 from managed_service_fixtures import AppDetails, AppManager
 
 from sending.backends.websocket import WebsocketManager
@@ -73,22 +74,6 @@ async def test_basic_send(manager: WebsocketManager):
     assert reply == {"type": "unauthed_echo_reply", "text": "Hello plain_manager"}
 
 
-async def test_response_header(manager: WebsocketManager):
-    """
-    The test websocket server will return a handful of response headers as part of the
-    websocket connection, such as {'upgrade': 'websocket', 'connection': 'Upgrade'}, etc.
-    It also includes a custom header {'foo': 'bar'}. In real world situations that response
-    header might be something like {'rtu-session-id': '<uuid>'}. Test that we save off
-    the response headers to the Manager instance on connect.
-    """
-    await manager.initialize()
-    # Give it a moment to connect
-    await asyncio.sleep(0.01)
-    assert (
-        manager.response_headers.get("foo") == "bar"
-    ), f"Missing foo: bar from {dict(manager.response_headers)}"
-
-
 async def test_message_hooks(json_manager: WebsocketManager):
     """
     Test that the inbound and outbound message hooks serialize/deserialize json
@@ -111,31 +96,6 @@ async def test_init_hook(json_manager: WebsocketManager):
     await json_manager.initialize()
     reply = await run_until_message_type(json_manager, "unauthed_echo_reply")
     assert reply == {"type": "unauthed_echo_reply", "text": "Hello init_hook"}
-
-
-@pytest.mark.xfail(reason="I don't know why this test doesn't work. Nick HALP")
-async def test_bad_auth_hook(json_manager: WebsocketManager):
-    """
-    Test that if someone adds an auth_hook but forgets to attach
-    a callback which will call .on_auth, that the ._publish method will
-    time out instead of awaiting .authed_ws forever
-    """
-
-    async def auth_hook(mgr: WebsocketManager):
-        # auth_hook can't use mgr.send because that is goign to wait for authed_ws,
-        # which doesn't get set until auth reply!
-        # So send over the unauth_ws Future.
-        # Also note that the outbound_message_hook isn't applied!
-        ws = await mgr.unauth_ws
-        msg = json.dumps({"type": "auth_request", "token": str(uuid.UUID(int=1))})
-        await ws.send(msg)
-
-    json_manager.auth_hook = auth_hook
-    json_manager.publish_timeout = 1
-    await json_manager.initialize()
-    with pytest.raises(asyncio.TimeoutError):
-        await json_manager.send({"type": "authed_echo_request", "text": "Hello auth"})
-        await asyncio.sleep(2)
 
 
 async def test_auth_hook(json_manager: WebsocketManager):
@@ -234,6 +194,78 @@ async def test_hooks_in_subclass(websocket_server: AppDetails):
     mgr.send({"type": "authed_echo_request", "text": "Hello subclass"})
     reply = await run_until_message_type(mgr, "authed_echo_reply")
     assert reply == {"type": "authed_echo_reply", "text": "Hello subclass"}
+    await mgr.shutdown()
+
+
+@pytest.fixture(name="log_output")
+def fixture_log_output():
+    return structlog.testing.LogCapture()
+
+
+@pytest.fixture
+def fixture_configure_structlog(log_output):
+    structlog.configure(
+        processors=[
+            structlog.contextvars.merge_contextvars,
+            structlog.processors.CallsiteParameterAdder(
+                {structlog.processors.CallsiteParameter.FUNC_NAME}
+            ),
+            log_output,
+        ]
+    )
+
+
+@pytest.mark.usefixtures("fixture_configure_structlog")
+async def test_structlog_contextvars_worker_hook(websocket_server: AppDetails, log_output):
+    """
+    Test that we can bind contextvars within the context_hook method and that any callbacks
+    or outbound publishing methods will include those in logs.
+    """
+
+    class Sub(WebsocketManager):
+        def __init__(self, ws_url):
+            super().__init__(ws_url)
+            self.session_id = None
+            self.register_callback(self.log_received)
+
+        async def context_hook(self):
+            structlog.contextvars.bind_contextvars(session_id=self.session_id)
+
+        async def connect_hook(self, mgr):
+            ws = await self.unauth_ws
+            self.session_id = ws.response_headers.get("session_id")
+
+        async def inbound_message_hook(self, raw_contents: str):
+            return json.loads(raw_contents)
+
+        async def outbound_message_hook(self, msg: dict):
+            return json.dumps(msg)
+
+        async def _publish(self, message: QueuedMessage):
+            await super()._publish(message)
+            structlog.get_logger().info(f"Publishing {message.contents}")
+
+        async def log_received(self, message: dict):
+            structlog.get_logger().info(f"Received {message}")
+
+    mgr = Sub(ws_url=websocket_server.ws_base + "/ws")
+    await mgr.initialize()
+    # Wait until we're connected before sending a message, otherwise the outbound worker
+    # will drop into .send / ._publish before we have a session_id set
+    await mgr.connected.wait()
+    mgr.send({"type": "unauthed_echo_request", "text": "Hello 1"})
+    # move forward in time until we get the next message from the webserver
+    await mgr.next_event.wait()
+    publish_log = log_output.entries[0]
+    assert publish_log["event"] == 'Publishing {"type": "unauthed_echo_request", "text": "Hello 1"}'
+    assert publish_log["session_id"]
+    assert publish_log["func_name"] == "_publish"
+
+    receive_log = log_output.entries[1]
+    assert receive_log["event"] == "Received {'type': 'unauthed_echo_reply', 'text': 'Hello 1'}"
+    assert receive_log["session_id"]
+    assert receive_log["func_name"] == "log_received"
+
     await mgr.shutdown()
 
 

--- a/tests/test_websocket_backend.py
+++ b/tests/test_websocket_backend.py
@@ -197,6 +197,8 @@ async def test_hooks_in_subclass(websocket_server: AppDetails):
     await mgr.shutdown()
 
 
+# Two fixtures below used by test_structlog_contextvars_worker_hook
+# Pattern pulled from https://www.structlog.org/en/stable/testing.html
 @pytest.fixture(name="log_output")
 def fixture_log_output():
     return structlog.testing.LogCapture()

--- a/tests/websocket_server.py
+++ b/tests/websocket_server.py
@@ -47,7 +47,7 @@ class WebsocketManager:
     dependency = singleton
 
     async def connect(self, session: WebsocketSession):
-        await session.ws.accept(headers=[(b"foo", b"bar")])
+        await session.ws.accept(headers=[(b"session_id", str(uuid.uuid4()).encode())])
         self.sessions.append(session)
 
     async def disconnect(self, session: WebsocketSession):


### PR DESCRIPTION
`context_hook` that's called by inbound worker, outbound worker, and poll worker during their respective `while True` loops. Intended to be used to set `structlog.contextvars.bind_contextvars` in application code. Can be defined as class methods or attached to an instance.

Related PA issue https://github.com/noteable-io/planar-ally/pull/243