### PR TITLE
run_once argument when registering callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2023-05-08
+### Added
+- `manager.register_callback(cb, run_once=True)` argument to deregister callbacks after they've been called a single time
+
 ## [0.3.0] - 2023-04-26
 ### Added
 - Standard Noteable open source patterns

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sending"
-version = "0.3.0"
+version = "0.3.1"
 description = "Library for pub/sub usage within an async application"
 authors = ["Nicholas Wold <nick@nicholaswold.com>"]
 
@@ -49,3 +49,6 @@ line-length = 100
 line_length = 100
 multi_line_output = 3
 include_trailing_comma = true
+
+[tool.ruff]
+max-line-length = 100


### PR DESCRIPTION
We want to do things like send out an RTU `new_delta_request` event and be able to await an asyncio Event/Future that is resolved by a callback that sees `new_delta_event` with the same transaction id as the request. After getting that a single time though, we can drop the callback